### PR TITLE
Updates for go, docker base

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hpinc/tcli
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/itchyny/gojq v0.12.19

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine3.23 AS builder
+FROM golang:1.26.5-alpine3.24 AS builder
 ADD . /go/src/tcli
 WORKDIR /go/src/tcli
 
@@ -8,10 +8,7 @@ go build -o bin/tcli \
 -ldflags "-s -w" cmd/main.go
 
 # use a minimal alpine image
-FROM alpine:3.23.4
-RUN apk update --no-cache && \
-apk upgrade && \
-apk add busybox=1.37.0-r30
+FROM alpine:3.24.1
 
 # make tcli available in path
 COPY --from=builder /go/src/tcli/bin/tcli /usr/local/bin/tcli


### PR DESCRIPTION
- Update go to 1.26.5
- Update docker base images to use alpine:3.24.1